### PR TITLE
Remove unused import 'torch.autograd.Variable'.

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+
 
 class contracting(nn.Module):
 	def __init__(self):


### PR DESCRIPTION
The 'torch.autograd.Variable' is an unused import.